### PR TITLE
Update nginx.conf to overcome AWS deplayment issue

### DIFF
--- a/configs/nginx.conf
+++ b/configs/nginx.conf
@@ -22,7 +22,7 @@ http {
 	client_max_body_size 256M;
 	# server_tokens off;
 
-	# server_names_hash_bucket_size 64;
+	server_names_hash_bucket_size 128;
 	# server_name_in_redirect off;
 
 	include /etc/nginx/mime.types;


### PR DESCRIPTION
By default it is not enough to have standard server_names_hash_bucket_size setting due to AWS Lighsail has >64 symbol default URL length.